### PR TITLE
Refactor the pinMode call from the constructor; allow digital and inverted outputs.

### DIFF
--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -16,8 +16,10 @@ namespace RBD {
     }
   }
 
-  void Light::setupPin(int pin) {
+  void Light::setupPin(int pin, bool output_pin_digital, bool output_inverted) {
     _pin = pin;
+    _output_pin_digital = output_pin_digital;
+    _output_inverted = output_inverted;
     pinMode(_pin, OUTPUT);
   }
 
@@ -51,7 +53,16 @@ namespace RBD {
       if(stop_everything) {
         _stopEverything();
       }
-      analogWrite(_pin, value);
+      const int actual_output_value = _output_inverted ? (255 - value) : value;
+      if (_output_pin_digital) {
+        if (actual_output_value >= 127) {
+          digitalWrite(_pin, HIGH);
+        } else {
+          digitalWrite(_pin, LOW);
+        }
+      } else {
+        analogWrite(_pin, actual_output_value);
+      }
       _pwm_value = value;
     }
   }

--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -10,6 +10,13 @@
 namespace RBD {
   Light::Light(int pin)
   : _up_timer(), _on_timer(), _down_timer(), _off_timer() {
+    if (pin != -1) {
+      _pin = pin;
+      pinMode(_pin, OUTPUT);
+    }
+  }
+
+  void Light::setupPin(int pin) {
     _pin = pin;
     pinMode(_pin, OUTPUT);
   }
@@ -40,7 +47,7 @@ namespace RBD {
   }
 
   void Light::setBrightness(int value, bool stop_everything) {
-    if(value > -1 && value < 256){
+    if(value > -1 && value < 256 && _pin != -1){
       if(stop_everything) {
         _stopEverything();
       }

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -13,7 +13,7 @@ namespace RBD {
   class Light {
     public:
       Light(int pin = -1);
-      void setupPin(int pin);
+      void setupPin(int pin, bool output_pin_digital = false, bool output_inverted = false);
       void on(bool stop_everything = true);
       void off(bool stop_everything = true);
       bool isOn();
@@ -31,6 +31,8 @@ namespace RBD {
     private:
       // global
       int _pin = -1;
+      bool _output_pin_digital = false;
+      bool _output_inverted = false;
       int _times;
       int _pwm_value;
       bool _forever = false;

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -12,7 +12,8 @@
 namespace RBD {
   class Light {
     public:
-      Light(int pin);
+      Light(int pin = -1);
+      void setupPin(int pin);
       void on(bool stop_everything = true);
       void off(bool stop_everything = true);
       bool isOn();
@@ -29,7 +30,7 @@ namespace RBD {
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time);
     private:
       // global
-      int _pin;
+      int _pin = -1;
       int _times;
       int _pwm_value;
       bool _forever = false;


### PR DESCRIPTION
The pinMode call should not appear in the constructor but instead in the global setup() function, hence needs to be refactored out of the constructor (with backward-compatibility code, though).

The class is useful for digital outputs, not only PWM outputs, which can easily be chosen by a bool flag. And also the inversion of the output (for active-low circuitry) can easily be added. Thanks!
