### PR TITLE
Allow current sink and a lightweight baseclass

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,5 @@
 Light	KEYWORD1
+SimpleLight	KEYWORD1
 on	KEYWORD2
 off	KEYWORD2
 isOn	KEYWORD2

--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -21,6 +21,10 @@ namespace RBD {
   void SimpleLight::on(bool _stop_everything) { // default: true
     setBrightness(255, _stop_everything);
   }
+  
+  void SimpleLight::toggle() {
+    setBrightness(255 - getBrightness());
+  }
 
   void SimpleLight::off(bool _stop_everything) { // default: true
     setBrightness(0, _stop_everything);

--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -10,16 +10,24 @@
 namespace RBD {
   SimpleLight::SimpleLight(int pin, bool isSink) {
     _pin = pin;
-	_isSink = isSink;
-	
-	if (isSink) {
+    _isSink = isSink;
+
+    if (isSink) {
       analogWrite(_pin, 255);
-	}
+    }
     pinMode(_pin, OUTPUT);
   }
 
   void SimpleLight::on(bool _stop_everything) { // default: true
     setBrightness(255, _stop_everything);
+  }
+  
+  void SimpleLight::setState(bool state, bool _stop_everything) { // default: true
+    if (state) {
+      on(_stop_everything);
+    } else {
+      off(_stop_everything);
+    }
   }
   
   void SimpleLight::toggle() {
@@ -44,11 +52,11 @@ namespace RBD {
     }
     if(_pwm_value != value) {
       _pwm_value = constrain(value, 0, 255);
-	  if (_isSink) {
-		analogWrite(_pin, 255 - _pwm_value);
-	  } else {
-		analogWrite(_pin, _pwm_value);  
-	  }
+      if (_isSink) {
+        analogWrite(_pin, 255 - _pwm_value);
+      } else {
+        analogWrite(_pin, _pwm_value);  
+      }
     }
   }
 

--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -8,9 +8,14 @@
 #include <RBD_Light.h> // https://github.com/alextaujenis/RBD_Light
 
 namespace RBD {
-  Light::Light(int pin)
+  Light::Light(int pin, bool isSink)
   : _up_timer(), _on_timer(), _down_timer(), _off_timer() {
     _pin = pin;
+	_isSink = isSink;
+	
+	if (isSink) {
+      analogWrite(_pin, 255);
+	}
     pinMode(_pin, OUTPUT);
   }
 
@@ -45,7 +50,11 @@ namespace RBD {
     }
     if(_pwm_value != value) {
       _pwm_value = constrain(value, 0, 255);
-      analogWrite(_pin, _pwm_value);
+	  if (_isSink) {
+		analogWrite(_pin, 255 - _pwm_value);
+	  } else {
+		analogWrite(_pin, _pwm_value);  
+	  }
     }
   }
 

--- a/src/RBD_Light.cpp
+++ b/src/RBD_Light.cpp
@@ -8,8 +8,7 @@
 #include <RBD_Light.h> // https://github.com/alextaujenis/RBD_Light
 
 namespace RBD {
-  Light::Light(int pin, bool isSink)
-  : _up_timer(), _on_timer(), _down_timer(), _off_timer() {
+  SimpleLight::SimpleLight(int pin, bool isSink) {
     _pin = pin;
 	_isSink = isSink;
 	
@@ -19,32 +18,23 @@ namespace RBD {
     pinMode(_pin, OUTPUT);
   }
 
-  void Light::on(bool _stop_everything) { // default: true
+  void SimpleLight::on(bool _stop_everything) { // default: true
     setBrightness(255, _stop_everything);
   }
 
-  void Light::off(bool _stop_everything) { // default: true
+  void SimpleLight::off(bool _stop_everything) { // default: true
     setBrightness(0, _stop_everything);
   }
 
-  bool Light::isOn() {
+  bool SimpleLight::isOn() {
     return getBrightness() == 255;
   }
 
-  bool Light::isOff() {
+  bool SimpleLight::isOff() {
     return getBrightness() == 0;
   }
 
-  void Light::update() {
-    if(_blinking) {
-      _blink();
-    }
-    if(_fading) {
-      _fade();
-    }
-  }
-
-  void Light::setBrightness(int value, bool _stop_everything) {
+  void SimpleLight::setBrightness(int value, bool _stop_everything) {
     if(_stop_everything) {
       _stopEverything();
     }
@@ -58,16 +48,38 @@ namespace RBD {
     }
   }
 
-  void Light::setBrightnessPercent(int value, bool _stop_everything) {
+  void SimpleLight::setBrightnessPercent(int value, bool _stop_everything) {
     setBrightness(int(value / 100.0 * 255), _stop_everything);
   }
 
-  int Light::getBrightness() {
+  int SimpleLight::getBrightness() {
     return _pwm_value;
   }
 
-  int Light::getBrightnessPercent() {
+  int SimpleLight::getBrightnessPercent() {
     return int(getBrightness() / 255.0 * 100);
+  }
+  
+  void SimpleLight::_stopEverything() {
+    // do nothing
+  }
+
+
+
+
+
+  Light::Light(int pin, bool isSink)
+  : SimpleLight(pin, isSink), _up_timer(), _on_timer(), _down_timer(), _off_timer() {
+
+  }
+
+  void Light::update() {
+    if(_blinking) {
+      _blink();
+    }
+    if(_fading) {
+      _fade();
+    }
   }
 
   void Light::blink(unsigned long on_time, unsigned long off_time, int times) {

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -15,33 +15,34 @@ namespace RBD {
       SimpleLight(int pin, bool isSink = false);
       void on(bool _stop_everything = true);  // turn on the light, stop everything is for internal use only
       void off(bool _stop_everything = true); // turn off the light, stop everything is for internal use only
-	  void toggle();
+      void setState(bool state, bool _stop_everything = true); // turn off the light, stop everything is for internal use only
+      void toggle();
       bool isOn();                            // returns true when the light is at 100% brightness
       bool isOff();                           // returns true when the ligh is at 0% brightness
       void setBrightness(int value, bool _stop_everything = true);        // 0 - 255
       void setBrightnessPercent(int value, bool _stop_everything = true); // 0 - 100
       int getBrightness();        // 0 - 255
       int getBrightnessPercent(); // 0 - 100
-	protected:
-	  virtual void _stopEverything();
+    protected:
+      virtual void _stopEverything();
     private:
       // global
-	  bool _isSink;
+      bool _isSink;
       int _pin;
-      int _pwm_value = 0;	  
+      int _pwm_value = 0;
   };
   
   class Light: public SimpleLight {
     public:
-	  Light(int pin, bool isSink = false);
+      Light(int pin, bool isSink = false);
       void update();                          // process real-time methods
       void blink(unsigned long on_time, unsigned long off_time, int times);
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time, int times);
       // overloaded blink & fade for unlimited times
       void blink(unsigned long on_time, unsigned long off_time);
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time);
-	protected:
-	  void _stopEverything();
+    protected:
+      void _stopEverything();
     private:
       // global
       int _times;

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -12,7 +12,7 @@
 namespace RBD {
   class Light {
     public:
-      Light(int pin);
+      Light(int pin, bool isSink = false);
       void on(bool _stop_everything = true);  // turn on the light, stop everything is for internal use only
       void off(bool _stop_everything = true); // turn off the light, stop everything is for internal use only
       bool isOn();                            // returns true when the light is at 100% brightness
@@ -29,6 +29,7 @@ namespace RBD {
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time);
     private:
       // global
+	  bool _isSink;
       int _pin;
       int _times;
       int _pwm_value = 0;

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -15,6 +15,7 @@ namespace RBD {
       SimpleLight(int pin, bool isSink = false);
       void on(bool _stop_everything = true);  // turn on the light, stop everything is for internal use only
       void off(bool _stop_everything = true); // turn off the light, stop everything is for internal use only
+	  void toggle();
       bool isOn();                            // returns true when the light is at 100% brightness
       bool isOff();                           // returns true when the ligh is at 0% brightness
       void setBrightness(int value, bool _stop_everything = true);        // 0 - 255

--- a/src/RBD_Light.h
+++ b/src/RBD_Light.h
@@ -10,31 +10,41 @@
 #include <RBD_Timer.h>
 
 namespace RBD {
-  class Light {
+  class SimpleLight {
     public:
-      Light(int pin, bool isSink = false);
+      SimpleLight(int pin, bool isSink = false);
       void on(bool _stop_everything = true);  // turn on the light, stop everything is for internal use only
       void off(bool _stop_everything = true); // turn off the light, stop everything is for internal use only
       bool isOn();                            // returns true when the light is at 100% brightness
       bool isOff();                           // returns true when the ligh is at 0% brightness
-      void update();                          // process real-time methods
       void setBrightness(int value, bool _stop_everything = true);        // 0 - 255
       void setBrightnessPercent(int value, bool _stop_everything = true); // 0 - 100
       int getBrightness();        // 0 - 255
       int getBrightnessPercent(); // 0 - 100
+	protected:
+	  virtual void _stopEverything();
+    private:
+      // global
+	  bool _isSink;
+      int _pin;
+      int _pwm_value = 0;	  
+  };
+  
+  class Light: public SimpleLight {
+    public:
+	  Light(int pin, bool isSink = false);
+      void update();                          // process real-time methods
       void blink(unsigned long on_time, unsigned long off_time, int times);
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time, int times);
       // overloaded blink & fade for unlimited times
       void blink(unsigned long on_time, unsigned long off_time);
       void fade(unsigned long up_time, unsigned long on_time, unsigned long down_time, unsigned long off_time);
+	protected:
+	  void _stopEverything();
     private:
       // global
-	  bool _isSink;
-      int _pin;
       int _times;
-      int _pwm_value = 0;
       bool _forever  = false;
-      void _stopEverything();
       // blinking
       bool _blinking;
       void _blink();


### PR DESCRIPTION
- The constructor takes an argument to specify whether the Arduino is connected to the LED as current source or current sink. Default: Current source. (https://en.wikipedia.org/wiki/Current_sources_and_sinks)

- I split the class into a base class (SimpleLight) and a derived class (Light), where the base class has only basic functionality without blinking and fading. Important to keep the compilled size small, if you do not need the extended functionality.